### PR TITLE
Custom "Code of Conduct" pages for mod developers

### DIFF
--- a/GorillaLibrary/Behaviours/ConductBoardManager.cs
+++ b/GorillaLibrary/Behaviours/ConductBoardManager.cs
@@ -20,6 +20,8 @@ namespace GorillaLibrary.Behaviours;
 
 internal class ConductBoardManager : MonoBehaviour
 {
+    public static ConductBoardManager Instance { get; private set; }
+    
     private int PageCount => boardContent.Count;
 
     private readonly List<Section> boardContent = [];

--- a/GorillaLibrary/Behaviours/ConductBoardManager.cs
+++ b/GorillaLibrary/Behaviours/ConductBoardManager.cs
@@ -22,6 +22,8 @@ internal class ConductBoardManager : MonoBehaviour
 {
     public static ConductBoardManager Instance { get; private set; }
     
+    private static readonly Queue<Section> staticQueuedEntries = [];
+    
     private int PageCount => boardContent.Count;
 
     private readonly List<Section> boardContent = [];
@@ -51,6 +53,8 @@ internal class ConductBoardManager : MonoBehaviour
 
     public void Start()
     {
+        Instance = this;
+        
         buttonTemplate = FindFirstObjectByType<GameModeSelectorButtonLayout>().GetField<ModeSelectButton>("pf_button");
 
         stumpRootObject = Array.Find(ZoneUtility.Objects, gameObject => gameObject.name == "TreeRoom");
@@ -335,6 +339,11 @@ internal class ConductBoardManager : MonoBehaviour
     
     private void FlushQueuedEntries()
     {
+        while (staticQueuedEntries.Count > 0)
+        {
+            queuedEntries.Enqueue(staticQueuedEntries.Dequeue());
+        }
+
         while (queuedEntries.Count > 0)
         {
             boardContent.Add(queuedEntries.Dequeue());
@@ -354,6 +363,12 @@ internal class ConductBoardManager : MonoBehaviour
             queuedEntries.Enqueue(section);
         }
     }
+    
+    public static void QueueEntry(string title, string body)
+    {
+        staticQueuedEntries.Enqueue(new Section(title, body));
+    }
+    
     private struct Section
     {
         public bool UseBaseText;

--- a/GorillaLibrary/Behaviours/ConductBoardManager.cs
+++ b/GorillaLibrary/Behaviours/ConductBoardManager.cs
@@ -23,6 +23,10 @@ internal class ConductBoardManager : MonoBehaviour
     private int PageCount => boardContent.Count;
 
     private readonly List<Section> boardContent = [];
+    
+    private readonly Queue<Section> queuedEntries = new();
+    
+    private bool entriesInitialized = false;
 
     private ModeSelectButton buttonTemplate;
 
@@ -277,6 +281,9 @@ internal class ConductBoardManager : MonoBehaviour
 
             Melon<Mod>.Logger.Msg("added");
         }
+        
+        FlushQueuedEntries();
+        entriesInitialized = true;
     }
 
     public async Task DownloadEntries()
@@ -323,7 +330,28 @@ internal class ConductBoardManager : MonoBehaviour
             if (typesToRemove.Contains(type)) Destroy(components[i]);
         }
     }
+    
+    private void FlushQueuedEntries()
+    {
+        while (queuedEntries.Count > 0)
+        {
+            boardContent.Add(queuedEntries.Dequeue());
+        }
+    }
 
+    public void AddEntry(string title, string body)
+    {
+        var section = new Section(title, body);
+    
+        if (entriesInitialized)
+        {
+            boardContent.Add(section);
+        }
+        else
+        {
+            queuedEntries.Enqueue(section);
+        }
+    }
     private struct Section
     {
         public bool UseBaseText;

--- a/GorillaLibrary/Directory.Build.props
+++ b/GorillaLibrary/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project>
     <PropertyGroup>
-        <GamePath>C:\Program Files (x86)\Steam\steamapps\common\Gorilla Tag</GamePath>
+        <GamePath>/home/lapis/.local/share/Steam/steamapps/common/Gorilla Tag/</GamePath>
         <GameAssemblyPath>$(GamePath)\Gorilla Tag_Data\Managed</GameAssemblyPath>
         <MelonLoaderAssemblyPath>$(GamePath)\MelonLoader\net35</MelonLoaderAssemblyPath>
         <ModsPath>$(GamePath)\Mods</ModsPath>

--- a/GorillaLibrary/Utilities/ConductBoardUtility.cs
+++ b/GorillaLibrary/Utilities/ConductBoardUtility.cs
@@ -9,6 +9,12 @@ public static class ConductBoardUtility
     /// </summary>
     public static void AddEntry(string title, string body)
     {
+        if (ConductBoardManager.Instance == null)
+        {
+            ConductBoardManager.QueueEntry(title, body);
+            return;
+        }
+
         ConductBoardManager.Instance.AddEntry(title, body);
     }
 }

--- a/GorillaLibrary/Utilities/ConductBoardUtility.cs
+++ b/GorillaLibrary/Utilities/ConductBoardUtility.cs
@@ -1,0 +1,14 @@
+using GorillaLibrary.Behaviours;
+
+namespace GorillaLibrary.Utilities;
+
+public static class ConductBoardUtility
+{
+    /// <summary>
+    /// Adds a new page to the Code of Conduct board, the board supports rich text.
+    /// </summary>
+    public static void AddEntry(string title, string body)
+    {
+        ConductBoardManager.Instance.AddEntry(title, body);
+    }
+}


### PR DESCRIPTION
Adds the ability for mod developers to create custom pages in their mods, instead of just only having the default boards that GorillaLibrary automatically adds.

Example code:

```
public override void OnEarlyInitializeMelon()
{
    GorillaLibrary.Utilities.ConductBoardUtility.AddEntry("GorillaTrials", "GTrials COC board works woah\n\n<color=yellow>we win these ones!</color>");
}
```

Result:

<img width="763" height="814" alt="Screenshot_20260503_134410" src="https://github.com/user-attachments/assets/73a3deca-73b7-40b1-98e5-324c0fee6f04" />
